### PR TITLE
Add documentation for using 'like' in a where clause

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -37,6 +37,10 @@ consumer.query()
     .on('success', function(rows) { console.log(rows); })
     .on('error', function(error) { console.error(error); });
 
+p. Using 'like' in a where clause:
+
+bc.. .where("namelast like '%MITH'")
+
 h3. Producer API
 
 You can add, update, replace, delete, and upsert rows, as well as truncate a dataset.


### PR DESCRIPTION
For someone who's first experience with the Socrata API, finding out how to do a 'like' query wasn't easy. I spoke with Chris Metcalf at a Seattle Open Data meetup, and he showed me the correct way to do it. I figured it should be documented for future users.