### PR TITLE
Update readme with clarifying details on publishing APIs

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -44,7 +44,8 @@ bc.. .where("namelast like '%MITH'")
 h3. Producer API
 
 You can add, update, replace, delete, and upsert rows, as well as truncate a dataset.
-Note: This library uses the Socrata Open Data API (SODA), which differs in functionality from the "Socrata Data Management API":https://socratapublishing.docs.apiary.io. When automating updates to Socrata datasets that utilize one or more on-platform Data Transforms, use the Data Management API to consistently apply those specified transforms. For more on the difference between SODA and the Data Management API, see the latter API's "documentation":https://socratapublishing.docs.apiary.io
+
+Note: This library uses the Socrata Open Data API (SODA), which differs in functionality from the "Socrata Data Management API":https://socratapublishing.docs.apiary.io. When automating updates to Socrata datasets that utilize one or more on-platform Data Transforms, use the Data Management API to consistently apply those specified transforms. For more on the difference between SODA and the Data Management API, see the latter API's "documentation":https://socratapublishing.docs.apiary.io.
 
 bc.. var producer = new soda.Producer('sandbox.demo.socrata.com', sodaConnectionOptions);
 

--- a/README.textile
+++ b/README.textile
@@ -44,9 +44,7 @@ bc.. .where("namelast like '%MITH'")
 h3. Producer API
 
 You can add, update, replace, delete, and upsert rows, as well as truncate a dataset.
-Note: This library uses the Socrata Open Data API (SODA), which differs in functionality from the "Socrata Data Management API":https://socratapublishing.docs.apiary.io/#
-When automating updates to Socrata datasets that utilize one or more on-platform Data Transforms, use the Data Management API to consistently apply those specified transforms.
-For more on the difference between SODA and the Data Management API, see the latter API's "documentation":https://socratapublishing.docs.apiary.io/#
+Note: This library uses the Socrata Open Data API (SODA), which differs in functionality from the "Socrata Data Management API":https://socratapublishing.docs.apiary.io. When automating updates to Socrata datasets that utilize one or more on-platform Data Transforms, use the Data Management API to consistently apply those specified transforms. For more on the difference between SODA and the Data Management API, see the latter API's "documentation":https://socratapublishing.docs.apiary.io
 
 bc.. var producer = new soda.Producer('sandbox.demo.socrata.com', sodaConnectionOptions);
 

--- a/README.textile
+++ b/README.textile
@@ -44,6 +44,9 @@ bc.. .where("namelast like '%MITH'")
 h3. Producer API
 
 You can add, update, replace, delete, and upsert rows, as well as truncate a dataset.
+Note: This library uses the Socrata Open Data API (SODA), which differs in functionality from the "Socrata Data Management API":https://socratapublishing.docs.apiary.io/#
+When automating updates to Socrata datasets that utilize one or more on-platform Data Transforms, use the Data Management API to consistently apply those specified transforms.
+For more on the difference between SODA and the Data Management API, see the latter API's "documentation":https://socratapublishing.docs.apiary.io/#
 
 bc.. var producer = new soda.Producer('sandbox.demo.socrata.com', sodaConnectionOptions);
 


### PR DESCRIPTION
Added brief note to Readme. Just clearing up potential confusion when users update datasets with SODA-backed libraries but also need on-platform transforms to run. 